### PR TITLE
Export models and accuracies

### DIFF
--- a/moses-scripts/FitnessFunctions.md
+++ b/moses-scripts/FitnessFunctions.md
@@ -5,7 +5,7 @@ This document contains a few suggestions to map model scores (gotten
 from MOSES) into hypergraphs.
 
 I'm discussing 2 fitnesses, used by Mike, accuracy (1 - score, in
-Mike's terminology) and balance accuracy.
+Mike's terminology) and balanced accuracy.
 
 Accuracy
 --------

--- a/moses-scripts/FitnessFunctions.md
+++ b/moses-scripts/FitnessFunctions.md
@@ -1,0 +1,71 @@
+Fitness Functions
+=================
+
+This document contains a few suggestions to map model scores (gotten
+from MOSES) into hypergraphs.
+
+I'm discussing 2 fitnesses, used by Mike, accuracy (1 - score, in
+Mike's terminology) and balance accuracy.
+
+Accuracy
+--------
+
+ACC = (TP + TN) / (P + N)
+
+We define an Accuracy predicate, that takes a model and dataset (or
+target feature) as arguments. The model, $M, is itself a predicate
+that evaluates to 1 (the confidence is let aside for now) when the
+individual $X is classified positively, 0 when it is classified
+negatively.
+
+Similarity the target feature, $D, is also a predicate that evaluates
+to 1 when the individual $X has its target feature active, 0
+otherwise.
+
+```
+EquivalenceLink <1>
+    BindLink
+        ListLink
+            $M
+            $D
+        EvaluationLink
+            PredicateNode "Accuracy"
+            ListLink
+                $M
+                $D
+    BindLink
+        ListLink
+            $M
+            $D
+        AverageLink
+            $X
+            EquivalenceLink
+                ExecutionOutputLink
+                    GetStrength 
+                    EvaluationLink
+                        $M
+                        $X
+                ExecutionOutputLink
+                    GetStrength 
+                    EvaluationLink
+                        $D
+                        $X
+```
+
+It turns out the TV on the AverageLink is gonna match the accuracy,
+given $M and $D. Indeed, the accuracy is the average number of times
+the model is correct with respect to the dataset. With this
+representation, given the dataset and the model, PLN can directly
+build the Accuracy predicate.
+
+In the absence of dataset, and given the accuracy of each model, one
+may directly write down the Accuracy predicate for each model, and
+target feature:
+
+```
+EvaluationLink <model accuracy>
+    PredicateNode "Accuracy"
+    ListLink
+        PredicateNode <MODEL>
+        PredicateNode <TARGET FEATURE>
+```

--- a/moses-scripts/export_models_and_fitness.sh
+++ b/moses-scripts/export_models_and_fitness.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Little script to export the models and their scores, given to a CSV,
+# following Mike's format, 3 columns, the combo program, then its
+# score (that is 1 - accuracy), and finally it's balanced accuracy.
+#
+# The model will be labeled FILENAME:moses_model_INDEX
+#
+# where FILENAME is the basename of the filename provided in argument,
+# and INDEX is the row index of the model (starting by 0)
+#
+# The exported hypergraphs are
+#
+# 1. The model itself associated with its label (MODEL_PREDICATE_NAME)
+#
+# EquivalenceLink <1, 1>
+#     PredicateNode MODEL_PREDICATE_NAME
+#     MODEL
+#
+# 2. The label associated with its accuracy
+#
+# EvaluationLink <accuracy>
+#     PredicateNode "accuracy"
+#     ListLink
+#         PredicateNode PREDICATE_MODEL_NAME
+#         PredicateNode TARGET_FEATURE_NAME
+#
+# 3. The label associated with its balanced accuracy
+#
+# EvaluationLink <balanced_accuracy>
+#     PredicateNode "balancedAccuracy"
+#     ListLink
+#         PredicateNode PREDICATE_MODEL_NAME
+#         PredicateNode TARGET_FEATURE_NAME
+
+set -u
+# set -x
+
+####################
+# Program argument #
+####################
+if [[ $# != 3 ]]; then
+    echo "Usage: $0 MODEL_CSV_FILE COGSERVER_HOST COGSERVER_PORT"
+    echo "Example: $0 chr10_moses.5x10.csv localhost 17001"
+    exit 1
+fi
+
+#############
+# Constants #
+#############
+readonly MODEL_CSV_FILE="$1"
+readonly COGSERVER_HOST="$2"
+readonly COGSERVER_PORT="$3"
+readonly BASE_MODEL_CSV_FILE="$(basename "$MODEL_CSV_FILE")"
+
+#############
+# Functions #
+#############
+
+# Pad $1 symbol with up to $2 0s
+pad() {
+    local pad_expression="%0${2}d"
+    printf "$pad_expression" "$1"
+}
+
+# Given
+#
+# 1. a model predicate name
+#
+# 2. a combo model
+#
+# return a scheme code defining the equivalence between the model name
+# and the model:
+#
+# EquivalenceLink <1, 1>
+#     PredicateNode MODEL_PREDICATE_NAME
+#     MODEL
+model_name_def() {
+    local name="$1"
+    local model="$2"
+    echo "(EquivalenceLink (stv 1.0 1.0) (PredicateNode \"${name}\") $model)"
+}
+
+# Given
+#
+# 1. a model predicate name
+#
+# 2. a target feature name
+#
+# 3. an accuracy
+#
+# return a scheme code relating the model predicate with the accuracy:
+#
+# EvaluationLink <accuracy>
+#     PredicateNode "accuracy"
+#     ListLink
+#         PredicateNode PREDICATE_MODEL_NAME
+#         PredicateNode TARGET_FEATURE_NAME
+model_accuracy_def() {
+    local name="$1"
+    local target="$2"
+    local accuracy="$3"
+    echo "(EvaluationLink (stv $accuracy 1) (PredicateNode \"accuracy\") (ListLink (PredicateNode \"$name\") (PredicateNode \"$target\")))"
+}
+
+# Like above but for balanced accuracy
+model_balanced_accuracy_def() {
+    local name="$1"
+    local target="$2"
+    local accuracy="$3"
+    echo "(EvaluationLink (stv $accuracy 1) (PredicateNode \"balancedAccuracy\") (ListLink (PredicateNode \"$name\") (PredicateNode \"$target\")))"
+}
+
+########
+# Main #
+########
+
+(echo "scm";
+    OLDIFS="$IFS"
+    IFS=","
+    i=0                             # used to give unique names to models
+    while read combo score balanced_accuracy; do
+        # Skip if that's the header
+        if [[ $combo =~ combo ]]; then
+            continue
+        fi
+
+        # Output model name predicate associated with model
+        model_name="${BASE_MODEL_CSV_FILE}:moses_model_$(pad $i 3)"
+        scm_model="$(combo-fmt-converter -c "$combo" -f scheme)"
+        echo "$(model_name_def "$model_name" "$scm_model")"
+
+        # Output model accuracy
+        accuracy=$(bc <<< "1 - $score")
+        echo "$(model_accuracy_def "$model_name" aging $accuracy)"
+
+        # Output model balanced accuracy
+        echo "$(model_balanced_accuracy_def "$model_name" aging $balanced_accuracy)"
+
+        ((++i))
+    done < "$MODEL_CSV_FILE"
+    IFS="$OLDIFS"
+) | telnet "$COGSERVER_HOST" "$COGSERVER_PORT"

--- a/moses-scripts/test.sh
+++ b/moses-scripts/test.sh
@@ -65,7 +65,7 @@ hr2i() {
 
 # Pad $1 symbol with up to $2 0s
 pad() {
-    pad_expression="%0${2}d"
+    local pad_expression="%0${2}d"
     printf "$pad_expression" "$1"
 }
 
@@ -100,6 +100,20 @@ train_test_split() {
             echo "$line" >> "${DATAFILE_TEST}"
         fi
     done < <(tail -n +2 "$DATAFILE")
+}
+
+# Given
+#
+# 1. a model name
+#
+# 2. a combo model
+#
+# return a scheme code defining the equivalence between the model name
+# and the model.
+model_def() {
+    name="$1"
+    model="$2"
+    echo "(EquivalenceLink (stv 1.0 1.0) (PredicateNode \"${name}\") $model)"
 }
 
 ########
@@ -155,7 +169,7 @@ infoEcho "Load MOSES models into the AtomSpace"
     i=0
     while read line; do
         moses_model_name="moses_$(pad $i 3)"
-        echo "(EquivalenceLink (stv 1.0 1.0) (EvaluationLink (PredicateNode \"${moses_model_name}\") (VariableNode \"\$X\")) $line)"
+        echo "$(model_def "$moses_model_name" "$line")"
         ((++i))
     done < "$moses_output_file"
 ) | "$opencog_repo_path/scripts/run_telnet_cogserver.sh"


### PR DESCRIPTION
Add a script
```
moses-scripts/export_models_and_fitness.sh
```

To export models and their accuracies. You may run the script without argument to get its usage, and more information can be found in the header comment of the script itself.