### PR TITLE
Export models precisions

### DIFF
--- a/moses-scripts/FitnessFunctions.md
+++ b/moses-scripts/FitnessFunctions.md
@@ -5,7 +5,7 @@ This document contains a few suggestions to map model scores (gotten
 from MOSES) into hypergraphs.
 
 I'm discussing 2 fitnesses, used by Mike, accuracy (1 - score, in
-Mike's terminology) and balanced accuracy.
+Mike's terminology) and precision.
 
 Accuracy
 --------
@@ -29,7 +29,7 @@ EquivalenceLink <1>
             $M
             $D
         EvaluationLink
-            PredicateNode "Accuracy"
+            PredicateNode "accuracy"
             ListLink
                 $M
                 $D
@@ -64,8 +64,44 @@ target feature:
 
 ```
 EvaluationLink <model accuracy>
-    PredicateNode "Accuracy"
+    PredicateNode "accuracy"
     ListLink
         PredicateNode <MODEL>
         PredicateNode <TARGET FEATURE>
 ```
+
+Precision
+---------
+
+The cool thing about precision is that it translates directly into an
+Implication TV strength. that is
+
+```
+ImplicationLink <TV.s = model precision>
+    PredicateNode <MODEL>
+    PredicateNode <TARGET FEATURE>
+```
+
+Indeed, According to PLN (assuming all individuals are equiprobable)
+
+TV.s = Sum_x min(P(x), Q(x)) / Sum_x P(x)
+
+where P correspond to the predicate of a model, x runs over the
+individuals of the dataset.
+
+This corresponds indeed to the precision
+
+precision = TP / (TP + FP)
+
+as Sum_x P(x) is indeed the number of positively classified
+individuals (TP + FP), and Sum_x min(P(x), Q(x)) the number of
+correctly classified individuals, TP.
+
+Confidence
+----------
+
+The confidence can be
+
+c = n / (n+k)
+
+where n is the number of individuals, and k is a parameter.

--- a/moses-scripts/README.md
+++ b/moses-scripts/README.md
@@ -30,3 +30,9 @@ mkdir <MY_EXP>
 cd <MY_EXP>
 ../scripts/test.sh ../scripts/settings.sh
 ```
+
+Additional documentation
+------------------------
+
+See file FitnessFunctions.md for a discussion of how to represent the
+fitness functions in the AtomSpace.

--- a/moses-scripts/export_models_and_fitness.sh
+++ b/moses-scripts/export_models_and_fitness.sh
@@ -32,6 +32,12 @@
 #     ListLink
 #         PredicateNode PREDICATE_MODEL_NAME
 #         PredicateNode TARGET_FEATURE_NAME
+#
+# 4. The label associated with its precision
+#
+# ImplicationLink <precision>
+#     PredicateNode MODEL_PREDICATE_NAME
+#     PredicateNode TARGET_FEATURE_NAME
 
 set -u
 # set -x
@@ -104,11 +110,31 @@ model_accuracy_def() {
 }
 
 # Like above but for balanced accuracy
-model_balanced_accuracy_def() {
+model_precision_def() {
     local name="$1"
     local target="$2"
     local accuracy="$3"
     echo "(EvaluationLink (stv $accuracy 1) (PredicateNode \"balancedAccuracy\") (ListLink (PredicateNode \"$name\") (PredicateNode \"$target\")))"
+}
+
+# Given
+#
+# 1. a model predicate name
+#
+# 2. a target feature name
+#
+# 3. a precision
+#
+# return a scheme code relating the model predicate with its precision:
+#
+# ImplicationLink <precision>
+#     PredicateNode PREDICATE_MODEL_NAME
+#     PredicateNode TARGET_FEATURE_NAME
+model_accuracy_def() {
+    local name="$1"
+    local target="$2"
+    local precision="$3"
+    echo "(ImplicationLink (stv $accuracy 1) (PredicateNode \"$name\") (PredicateNode \"$target\"))"
 }
 
 ########
@@ -119,7 +145,7 @@ model_balanced_accuracy_def() {
     OLDIFS="$IFS"
     IFS=","
     i=0                             # used to give unique names to models
-    while read combo score balanced_accuracy; do
+    while read combo score balanced_accuracy precision; do
         # Skip if that's the header
         if [[ $combo =~ combo ]]; then
             continue
@@ -136,6 +162,9 @@ model_balanced_accuracy_def() {
 
         # Output model balanced accuracy
         echo "$(model_balanced_accuracy_def "$model_name" aging $balanced_accuracy)"
+
+        # Output model precision
+        echo "$(model_precision_def "$model_name" aging $precision)"
 
         ((++i))
     done < "$MODEL_CSV_FILE"

--- a/moses-scripts/export_models_and_fitness.sh
+++ b/moses-scripts/export_models_and_fitness.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Little script to export the models and their scores, given to a CSV,
-# following Mike's format, 3 columns, the combo program, then its
-# score (that is 1 - accuracy), and finally it's balanced accuracy.
+# following Mike's format, 4 columns, the combo program, then its
+# score (that is 1 - accuracy), it's balanced accuracy and its
+# precision.
 #
 # The model will be labeled FILENAME:moses_model_INDEX
 #


### PR DESCRIPTION
This patch modifies export_models_and_fitness.sh to export precision as well. To function correctly it assumes the model csv file has 4 columns, models, score, balanced accuracy and precision.