### PR TITLE
Correct include path proto to value

### DIFF
--- a/bioscience/types/BioScienceTypes.cc
+++ b/bioscience/types/BioScienceTypes.cc
@@ -25,4 +25,4 @@
 #define INHERITANCE_FILE "bioscience/types/atom_types.inheritance"
 #define INITNAME bioscience_types_init
 
-#include <opencog/atoms/proto/atom_types.cc>
+#include <opencog/atoms/value/atom_types.cc>


### PR DESCRIPTION
This is the corresponding fix for PR [#1930.](https://github.com/opencog/atomspace/pull/1930) as per the issue [Rename FloatValue to FloatSeq? #1880](https://github.com/opencog/atomspace/issues/1880#issuecomment-430348458).